### PR TITLE
chore(git): add Node/Express .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Node / Express .gitignore
+
+# Dependencies
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage
+coverage
+*.lcov
+
+# Build output
+/dist
+/build
+/.next
+.next
+/out
+
+# Cache
+.npm
+.yarn
+.pnpm-store
+.cache
+/.turbo
+/.parcel-cache
+
+# Env files
+.env
+.env.*
+!.env.example
+
+# OS / Editor
+.DS_Store
+Thumbs.db
+.idea
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Misc
+*.tsbuildinfo
+*.swp


### PR DESCRIPTION
What: Add a Node/Express-focused .gitignore to ignore dependencies, logs, build outputs, caches, and environment files.

Why: Keep the repository clean and avoid committing generated artifacts and secrets. Aligns with setting up a Node/Express API skeleton.

Verification: Verified locally by adding .gitignore and committing. No code changes.

Closes: N/A