### PR TITLE
ci(firebase): add App Hosting deploy on main

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "example-cursor-v1"
+  }
+}

--- a/.github/workflows/firebase-app-hosting.yml
+++ b/.github/workflows/firebase-app-hosting.yml
@@ -1,0 +1,32 @@
+name: Deploy to Firebase App Hosting
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy App Hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          firebase use example-cursor-v1 --token "$FIREBASE_TOKEN"
+          firebase deploy --only apphosting --token "$FIREBASE_TOKEN"
+
+# Prerequisites:
+# 1) Enable App Hosting API: https://console.developers.google.com/apis/api/firebaseapphosting.googleapis.com/overview?project=example-cursor-v1
+# 2) Create backend via Firebase Console (App Hosting) if none exists
+# 3) Add GitHub secret FIREBASE_TOKEN (generated via 'firebase login:ci')

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,9 @@
+{
+  "hosting": {
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}


### PR DESCRIPTION
What
- Add `.firebaserc` with project `example-cursor-v1`.
- Add GitHub Actions workflow to deploy Firebase App Hosting on push to `main`.
- Add minimal `firebase.json` placeholder.

Why
- Automate deployments of the Node app to Firebase App Hosting whenever `main` updates.

Notes
- Ensure App Hosting API is enabled for the project.
- Create an App Hosting backend in Firebase Console if one does not exist.
- Add repository secret `FIREBASE_TOKEN` (from `firebase login:ci`) for CI auth.
